### PR TITLE
feat: add CI for devnet deployment

### DIFF
--- a/.github/workflows/deploy-devnet.yml
+++ b/.github/workflows/deploy-devnet.yml
@@ -1,0 +1,37 @@
+name: Deploy to devnet
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build static amd64 binary
+        run: make build-static-linux-amd64
+
+      - name: Copy built binary via SSH
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.SERVER_IP }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_KEY }}
+          source: "build/gaiad-linux-amd64/gaiad"
+          target: /tmp/
+          strip_components: 2
+      
+      - name: Restart devnet with new binary version
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SERVER_IP }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_KEY }}
+          script: |
+            mv /tmp/gaiad ~/go/bin/gaiad
+            sudo systemctl restart cosmos.service


### PR DESCRIPTION
Adds a CI to deploy new versions of gaia  to devnet off of a `dev` branch